### PR TITLE
WIP mostly around getting an INPUT configured

### DIFF
--- a/.profile
+++ b/.profile
@@ -6,3 +6,6 @@
 
 export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LICENSE_KEY")"
 export NEW_RELIC_LOGS_ENDPOINT="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LOGS_ENDPOINT")"
+
+# fluent-bit doesn't support https: proxy URL. (Why?) This doesn't actually work. FIXME
+export HTTP_PROXY=`echo $PROXYROUTE | sed -e 's/https:/http:/'`

--- a/README.md
+++ b/README.md
@@ -28,19 +28,23 @@ To accomplish this for systems hosted on cloud.gov, the code in this repository 
     cf logs fluentbit-drain --recent
     ```
 
+## Finding your logs in New Relic
+
+Start by looking in "Logs -> All Logs." If you already have other logs feeding New Relic, you can filter by `plugin.type:"Fluent Bit"`. The default fluentbit.conf includes a "dummy" input that produces a single message. 
+
 ## Status
 
 - Can run `cf push` and see fluentbit running with the supplied configuration
 - No INPUT specified; we're just logging a dummy entry
-- We haven't tried it with a legit NR license key yet, so we haven't seen logs appearing at the far side
+- Test with a legit NR license key, and see logs appearing at the far side. (Single "dummy" message.) 
 
 ### TODO
 
-- Test with a legit NR license key, and see logs appearing at the far side (half done)
 - Configure the app to recognize a bound S3 bucket service in VCAP_SERVICES, and ship logs there as well
 - Set the INPUT clause to be what it should be for drained logs, following [this example for fluentd](https://docs.cloudfoundry.org/devguide/services/fluentd.html#config)
 - Port over all the [`datagov-logstack`](https://github.com/GSA/datagov-logstack) utility scripts for registering drains on apps/spaces
-- Look for and [use `https_proxy` for egress connections](https://docs.fluentbit.io/manual/administration/http-proxy)
+- Configure tls on the INPUT? 
+- Look for and [use `https_proxy` for egress connections](https://docs.fluentbit.io/manual/administration/http-proxy). Problem here: fluent-bit supports http_proxy/HTTP_PROXY but does not support the https protocol. See  [Note: "currently only HTTP is supported."](https://github.com/fluent/fluent-bit/blob/5686334b56ee9d92f0654b0a621113943b175b94/src/flb_utils.c#L1123)
 - Add tests?
 
 ## Contributing

--- a/fluentbit.conf
+++ b/fluentbit.conf
@@ -1,14 +1,30 @@
 [SERVICE]
-    flush     1
-    log_level info
+    flush        1
+    log_level    debug
+    parsers_file /home/vcap/deps/0/apt/etc/fluent-bit/parsers.conf
 
 [INPUT]
     name      dummy
     dummy     {"message":"a simple message", "temp": "0.74", "extra": "false"}
     samples   1
 
+[INPUT]
+    name syslog
+    host 127.0.0.1
+    port ${PORT}
+    mode tcp
+    parser syslog-rfc5424
+    tag cf.app
+    source_address_key log_source
 
-# TODO: 
+#     tls on
+#     message_length_limit 99990
+#     frame_type octet_count
+#     transport tls
+
+
+
+# TODO:
 #  - Refer to extracted env vars in the config below
 # [OUTPUT]
 #      Name s3
@@ -24,4 +40,3 @@
     base_uri  ${NEW_RELIC_LOGS_ENDPOINT}
     match     *
     api_key   ${NEW_RELIC_LICENSE_KEY}
-

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/home/vcap/deps/0/apt/opt/fluent-bit/bin/fluent-bit -P ${PORT} -c fluentbit.conf
+/home/vcap/deps/0/apt/opt/fluent-bit/bin/fluent-bit -c fluentbit.conf


### PR DESCRIPTION
Progress so far: 

- Verified that the "dummy" message is successfully logged to New Relic when New Relic credentials are present. 
- Learned that the fluentbit -P flag specifies the port for the optional fluentbit HTTP server, not the port for fluentbit to listen on, so removed that from the startup script. 
- Drafted an INPUT section for syslogs. fluentd and fluentbit syntax diverge on this one. 

Working on: 

- Proxy settings are not working in cloud.gov environment. I'm still noodling on this one. Fluentbit uses the HTTP_PROXY (or http_proxy) environment variable and only accepts "http" (not "https") as the protocol, but their docs claim that this works for HTTPS as well. (Current theory: HTTPS is supported, and the problem is elsewhere.)
- I was unable to verify the INPUT configuration using an app deployed in my sandbox environment because I could not set up a tcp route to that app. A log drain service pointed at an https route made http requests, which fluentbit was unable to parse with the syslog-rfc5424 parser (understandably!) 
  - Either cloud.gov does not allow users to create tcp routes, or ... 
  - I can create a tcp route, but first I must have a domain for it (guessing that all *.app.cloud.gov routes rely on ALB). 

