### PR TITLE
Add New Relic's output plugin -- proxy config works

### DIFF
--- a/.profile
+++ b/.profile
@@ -6,3 +6,10 @@
 
 export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LICENSE_KEY")"
 export NEW_RELIC_LOGS_ENDPOINT="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LOGS_ENDPOINT")"
+
+# Add HTTPS_PROXY (example):
+export HTTPS_PROXY=$PROXYROUTE
+
+# Include certs for proxy (turned out not to be needed for New Relic output plugin):
+# export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+# export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,11 +1,16 @@
-
 # Troubleshooting
 
 ## New Relic (nrlogs)
 
+### TODO: replace with "newrelic" examples
+
 These examples use the default "dummy" input and the "nrlogs" output in fluentbit.conf, with  `log_level info`.
 
 Follow the instructions in README.md to push the app and display the logs.
+
+You can get the full set of options for the nrlogs plugin by running this command:
+
+  `/home/vcap/deps/0/apt/opt/fluent-bit/bin/fluent-bit -o nrlogs -h`
 
 ### Success
 A successful startup for output to New Relic will show messages like this:

--- a/fluentbit.conf
+++ b/fluentbit.conf
@@ -1,14 +1,16 @@
 [SERVICE]
-    flush     1
-    log_level info
+    flush        1
+    log_level    trace
+    parsers_file /home/vcap/deps/0/apt/etc/fluent-bit/parsers.conf
+    Plugins_File plugins.conf
 
 [INPUT]
     name      dummy
-    dummy     {"message":"a simple message", "temp": "0.74", "extra": "false"}
+    dummy     {"message":"Using newrelic output plugin", "temp": "0.74", "extra": "false"}
     samples   1
 
 
-# TODO: 
+# TODO:
 #  - Refer to extracted env vars in the config below
 # [OUTPUT]
 #      Name s3
@@ -19,9 +21,9 @@
 #      total_file_size 50M
 #      upload_timeout 10m
 
-[OUTPUT]
-    name      nrlogs
-    base_uri  ${NEW_RELIC_LOGS_ENDPOINT}
-    match     *
-    api_key   ${NEW_RELIC_LICENSE_KEY}
 
+[OUTPUT]
+    Name newrelic
+    Match *
+    licenseKey ${NEW_RELIC_LICENSE_KEY}
+    endpoint ${NEW_RELIC_LOGS_ENDPOINT}

--- a/newrelic_output/README.md
+++ b/newrelic_output/README.md
@@ -1,0 +1,3 @@
+# New Relic Fluent Bit Output plugin
+
+This directory contains New Relic's output plugin for Fluent Bit. See: https://github.com/newrelic/newrelic-fluent-bit-output (compiled .so downloaded from Releases). 

--- a/plugins.conf
+++ b/plugins.conf
@@ -1,0 +1,2 @@
+[PLUGINS]
+    Path /home/vcap/app/newrelic_output/out_newrelic-linux-amd64-1.17.3.so


### PR DESCRIPTION
This configuration successfully sends a message to New Relic, using the proxy specified by HTTPS_PROXY. 

It turns out that this output plugin didn't need SSL_CERT_FILE defined. REQUESTS_CA_BUNDLE is already defined without my adding it to .profile (standard/default on ubuntu linux?). 