### PR TITLE
Add INPUT suitable to consume log-drain messages, and parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,17 @@ To accomplish this for systems hosted on cloud.gov, the code in this repository 
 ## Status
 
 - Can run `cf push` and see fluentbit running with the supplied configuration
-- No INPUT specified; we're just logging a dummy entry
-- We haven't tried it with a legit NR license key yet, so we haven't seen logs appearing at the far side
+- We have tested with a legit NR license key and seen logs appearing in NR.
+- Input configured to accept logs from a cf log-drain service.
+- Look for and use `HTTPS_PROXY` for egress connections (New Relic's plugin provides this) 
 
 ### TODO
 
-- Test with a legit NR license key, and see logs appearing at the far side (half done)
+- Improve the parsing of logs, to send appropriately structured data forward. 
 - Configure the app to recognize a bound S3 bucket service in VCAP_SERVICES, and ship logs there as well
-- Set the INPUT clause to be what it should be for drained logs, following [this example for fluentd](https://docs.cloudfoundry.org/devguide/services/fluentd.html#config)
 - Port over all the [`datagov-logstack`](https://github.com/GSA/datagov-logstack) utility scripts for registering drains on apps/spaces
-- Look for and [use `https_proxy` for egress connections](https://docs.fluentbit.io/manual/administration/http-proxy)
+- Restrict incoming traffic (by credentials if possible). 
+
 - Add tests?
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -37,11 +37,10 @@ To accomplish this for systems hosted on cloud.gov, the code in this repository 
 
 ### TODO
 
-- Improve the parsing of logs, to send appropriately structured data forward. 
+- Restrict incoming traffic (by credentials if possible). 
+- Futher improve the parsing of logs -- handle or include examples for nginx, apache log messages
 - Configure the app to recognize a bound S3 bucket service in VCAP_SERVICES, and ship logs there as well
 - Port over all the [`datagov-logstack`](https://github.com/GSA/datagov-logstack) utility scripts for registering drains on apps/spaces
-- Restrict incoming traffic (by credentials if possible). 
-
 - Add tests?
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ To accomplish this for systems hosted on cloud.gov, the code in this repository 
 
 ### TODO
 
-- Restrict incoming traffic (by credentials if possible). 
+- Add a web server. We're currently accepting HTTP requests but not sending a response, which is rude and will probably lead to excessive open connections. Web server needs to listen on ${PORT}, pipe data to fluentbit, and send a response (not necessarily in that order). 
+  - Restrict incoming traffic by credentials (basic auth)
+  - Restrict to cloud.gov egress ranges (52.222.122.97/32, 52.222.123.172/32)? 
 - Futher improve the parsing of logs -- handle or include examples for nginx, apache log messages
 - Configure the app to recognize a bound S3 bucket service in VCAP_SERVICES, and ship logs there as well
 - Port over all the [`datagov-logstack`](https://github.com/GSA/datagov-logstack) utility scripts for registering drains on apps/spaces

--- a/fluentbit.conf
+++ b/fluentbit.conf
@@ -1,6 +1,6 @@
 [SERVICE]
     flush        1
-    log_level    info
+    log_level    trace
     parsers_file parsers.conf
     parsers_file /home/vcap/deps/0/apt/etc/fluent-bit/parsers.conf
     plugins_File plugins.conf
@@ -14,6 +14,9 @@
     name tcp
     port ${PORT}
     format none
+    # TODO: We are accepting HTTP requests but not closing them. This helps but more research is needed.
+    # TODO: We're going to need an http server.
+    net.io_timeout              1
 
 
 # Uncomment to ship to s3

--- a/fluentbit.conf
+++ b/fluentbit.conf
@@ -38,33 +38,16 @@
     name parser
     match tcp.*
     key_name log
-    parser cg-http-post-parser
+    parser post-with-syslog
 
-# [FILTER]
-#     name parser
-#     match *
-#     key_name log
-#     parser post-with-syslog-rfc5424
 
-# [INPUT]
-#     name syslog
-#     port ${PORT}
-#     mode tcp
-#     parser syslog-rfc5424
-#     source_address_key log_source
-
-# This works but is commented out while testing other things.
 # [OUTPUT]
 #     Name newrelic
 #     Match *
 #     licenseKey ${NEW_RELIC_LICENSE_KEY}
 #     endpoint ${NEW_RELIC_LOGS_ENDPOINT}
 
-# [INPUT]
-#     Name http
-#     port ${PORT}
-
-
+# Comment this out to test by watching the logshipper's logs:
 [OUTPUT]
     name stdout
     match *

--- a/fluentbit.conf
+++ b/fluentbit.conf
@@ -1,12 +1,13 @@
 [SERVICE]
     flush        1
     log_level    trace
+    parsers_file parsers.conf
     parsers_file /home/vcap/deps/0/apt/etc/fluent-bit/parsers.conf
-    Plugins_File plugins.conf
+    plugins_File plugins.conf
 
 [INPUT]
     name      dummy
-    dummy     {"message":"Using newrelic output plugin", "temp": "0.74", "extra": "false"}
+    dummy     {"message":"A simple test message", "temp": "0.74", "extra": "false"}
     samples   1
 
 
@@ -21,9 +22,49 @@
 #      total_file_size 50M
 #      upload_timeout 10m
 
+[INPUT]
+    name tcp
+    port ${PORT}
+    format none
+
+# These next two filter stanzas work, in that fluentbit approves and produces regex-modified output.
+[FILTER]
+    name multiline
+    match tcp.*
+    multiline.key_content log
+    multiline.parser combine-http-post
+
+[FILTER]
+    name parser
+    match tcp.*
+    key_name log
+    parser cg-http-post-parser
+
+# [FILTER]
+#     name parser
+#     match *
+#     key_name log
+#     parser post-with-syslog-rfc5424
+
+# [INPUT]
+#     name syslog
+#     port ${PORT}
+#     mode tcp
+#     parser syslog-rfc5424
+#     source_address_key log_source
+
+# This works but is commented out while testing other things.
+# [OUTPUT]
+#     Name newrelic
+#     Match *
+#     licenseKey ${NEW_RELIC_LICENSE_KEY}
+#     endpoint ${NEW_RELIC_LOGS_ENDPOINT}
+
+# [INPUT]
+#     Name http
+#     port ${PORT}
+
 
 [OUTPUT]
-    Name newrelic
-    Match *
-    licenseKey ${NEW_RELIC_LICENSE_KEY}
-    endpoint ${NEW_RELIC_LOGS_ENDPOINT}
+    name stdout
+    match *

--- a/fluentbit.conf
+++ b/fluentbit.conf
@@ -27,19 +27,51 @@
     port ${PORT}
     format none
 
-# These next two filter stanzas work, in that fluentbit approves and produces regex-modified output.
+### Filters run in order of appearance ###
+# Combine multiple (headers + body)of an HTTP POST request into a single record.
 [FILTER]
     name multiline
     match tcp.*
     multiline.key_content log
     multiline.parser combine-http-post
 
+# Initial pass at parsing the body of the request.
 [FILTER]
     name parser
     match tcp.*
     key_name log
     parser post-with-syslog
+    # reserve_data: Keep all other fields
+    reserve_data Off
+    # preserve_key: Keep the key_name field (message)
+    preserve_key On
 
+# Further filter of the already-extracted message
+[FILTER]
+    name parser
+    match tcp.*
+    key_name message
+    parser extract-gauge
+    # reserve_data: Keep all other fields
+    reserve_data On
+    # preserve_key: Keep the key_name field (message)
+    preserve_key On
+
+# And so on ... (multiple passes let us capture fields in varying order)
+[FILTER]
+    name parser
+    match tcp.*
+    key_name message
+    parser extract-tags
+    reserve_data On
+    preserve_key On
+
+# Process selected keys (tags, gauge) into stringified JSON
+[FILTER]
+    name lua
+    match tcp.*
+    script scripts/parse_tags_with_eq_pairs.lua
+    call parse_tags_with_eq_pairs
 
 # [OUTPUT]
 #     Name newrelic

--- a/fluentbit.conf
+++ b/fluentbit.conf
@@ -1,6 +1,6 @@
 [SERVICE]
     flush        1
-    log_level    trace
+    log_level    info
     parsers_file parsers.conf
     parsers_file /home/vcap/deps/0/apt/etc/fluent-bit/parsers.conf
     plugins_File plugins.conf
@@ -10,7 +10,14 @@
     dummy     {"message":"A simple test message", "temp": "0.74", "extra": "false"}
     samples   1
 
+[INPUT]
+    name tcp
+    port ${PORT}
+    format none
 
+
+# Uncomment to ship to s3
+#
 # TODO:
 #  - Refer to extracted env vars in the config below
 # [OUTPUT]
@@ -22,10 +29,18 @@
 #      total_file_size 50M
 #      upload_timeout 10m
 
-[INPUT]
-    name tcp
-    port ${PORT}
-    format none
+# Uncomment to ship to New Relic
+# [OUTPUT]
+#     Name newrelic
+#     Match *
+#     licenseKey ${NEW_RELIC_LICENSE_KEY}
+#     endpoint ${NEW_RELIC_LOGS_ENDPOINT}
+
+# Uncomment to see the parsed messages in the logshipper's logs:
+[OUTPUT]
+    name stdout
+    match *
+
 
 ### Filters run in order of appearance ###
 # Combine multiple (headers + body)of an HTTP POST request into a single record.
@@ -41,20 +56,16 @@
     match tcp.*
     key_name log
     parser post-with-syslog
-    # reserve_data: Keep all other fields
     reserve_data Off
-    # preserve_key: Keep the key_name field (message)
     preserve_key On
 
-# Further filter of the already-extracted message
+# Further filter of the already-extracted fields
 [FILTER]
     name parser
     match tcp.*
     key_name message
     parser extract-gauge
-    # reserve_data: Keep all other fields
     reserve_data On
-    # preserve_key: Keep the key_name field (message)
     preserve_key On
 
 # And so on ... (multiple passes let us capture fields in varying order)
@@ -66,20 +77,18 @@
     reserve_data On
     preserve_key On
 
-# Process selected keys (tags, gauge) into stringified JSON
+# Process selected keys (tags, gauge) into (stringified) JSON
 [FILTER]
     name lua
     match tcp.*
-    script scripts/parse_tags_with_eq_pairs.lua
-    call parse_tags_with_eq_pairs
+    time_as_table On
+    script scripts/parse_keys_with_eq_pairs.lua
+    call parse_keys_with_eq_pairs
 
-# [OUTPUT]
-#     Name newrelic
-#     Match *
-#     licenseKey ${NEW_RELIC_LICENSE_KEY}
-#     endpoint ${NEW_RELIC_LOGS_ENDPOINT}
-
-# Comment this out to test by watching the logshipper's logs:
-[OUTPUT]
-    name stdout
-    match *
+# Parse the http headers into pairs.
+[FILTER]
+    name lua
+    match tcp.*
+    time_as_table On
+    script scripts/parse_http_headers.lua
+    call parse_http_headers

--- a/parsers.conf
+++ b/parsers.conf
@@ -20,11 +20,7 @@
 [PARSER]
     Name post-with-syslog
     Format regex
-    # syslog-rfc5424: ^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*?)\]|-)) (?<message>.+)$
-    # syslog-rfc3164: ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-    # This approach to grabbing a header works, but it will require our headers to be in consistent order:
-    # Regex /X-B3-Spanid: (?<b3_spanid>\S+).*^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]*) (?<ident>[^ ]+) \[(?<ptype>[^ ]+)\] - (?<message>.*)/m
-    Regex /^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]*) (?<ident>[^ ]+) \[(?<ptype>[^ ]+)\] - (?<message>.*)/m
+    Regex /(?<http_headers>.*)^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]*) (?<ident>[^ ]+) \[(?<ptype>[^ ]+)\] - (?<message>.*)/m
     Time_Key time
     Time_Format %Y-%m-%dT%H:%M:%S.%L%z
     Time_Keep On
@@ -39,7 +35,6 @@
     Format regex
     Regex /\[tags@\d+ (?<tags>[^\]]+)/m
 
-# [PARSER]
-#     Name convert-eq-pairs-to-json
-#     Format regex
-#     Regex /\[tags@\d+ (?<tags>[^\]]+)/m
+[PARSER]
+    Name string-to-json
+    Format json

--- a/parsers.conf
+++ b/parsers.conf
@@ -23,7 +23,23 @@
     # syslog-rfc5424: ^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*?)\]|-)) (?<message>.+)$
     # syslog-rfc3164: ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
     # This approach to grabbing a header works, but it will require our headers to be in consistent order:
-    Regex /X-B3-Spanid: (?<b3_spanid>\S+).*^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]*) (?<ident>[^ ]+) \[(?<ptype>[^ ]+)\] - (?<message>.*)/m
+    # Regex /X-B3-Spanid: (?<b3_spanid>\S+).*^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]*) (?<ident>[^ ]+) \[(?<ptype>[^ ]+)\] - (?<message>.*)/m
+    Regex /^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]*) (?<ident>[^ ]+) \[(?<ptype>[^ ]+)\] - (?<message>.*)/m
     Time_Key time
     Time_Format %Y-%m-%dT%H:%M:%S.%L%z
     Time_Keep On
+
+[PARSER]
+    Name extract-gauge
+    Format regex
+    Regex /\[gauge@\d+ (?<gauge>[^\]]+)/m
+
+[PARSER]
+    Name extract-tags
+    Format regex
+    Regex /\[tags@\d+ (?<tags>[^\]]+)/m
+
+# [PARSER]
+#     Name convert-eq-pairs-to-json
+#     Format regex
+#     Regex /\[tags@\d+ (?<tags>[^\]]+)/m

--- a/parsers.conf
+++ b/parsers.conf
@@ -1,0 +1,36 @@
+[MULTILINE_PARSER]
+    # Combine an HTTP POST into a single message
+    name combine-http-post
+    type regex
+    #
+    # Regex rules for multiline parsing
+    # ---------------------------------
+    #
+    # configuration hints:
+    #
+    #  - first state always has the name: start_state
+    #  - every field in the rule must be inside double quotes
+    #
+    # rules |   state name  | regex pattern                  | next state
+    # ------|---------------|--------------------------------------------
+    rule      "start_state"   "/^POST \S+ HTTP\/1\.1\r/"       "cont"
+    rule      "cont"          "/.*/"                         "cont"
+
+
+[PARSER]
+    Name cg-http-post-parser
+    Format regex
+    # Regex /<\d+>\d+\s(?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+\S+)\s.+\s-\s(?<message>.*)/m
+    Regex /\<(?<pri>[0-9]{1,5})\>1 (?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+\S+)\s.+\s-\s(?<message>.*)/m
+    Time_Key time
+    Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+    Time_Keep On
+
+[PARSER]
+    Name post-with-syslog-rfc5424
+    Format regex
+    # Regex       /.*\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*?)\]|-)) (?<message>.+).*/m
+    Regex /\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-a0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*?)\]|-)) (?<message>.*)/m
+    # Time_Key time
+    # Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+    # Time_Keep On

--- a/parsers.conf
+++ b/parsers.conf
@@ -18,19 +18,12 @@
 
 
 [PARSER]
-    Name cg-http-post-parser
+    Name post-with-syslog
     Format regex
-    # Regex /<\d+>\d+\s(?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+\S+)\s.+\s-\s(?<message>.*)/m
-    Regex /\<(?<pri>[0-9]{1,5})\>1 (?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+\S+)\s.+\s-\s(?<message>.*)/m
+    # syslog-rfc5424: ^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*?)\]|-)) (?<message>.+)$
+    # syslog-rfc3164: ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+    # This approach to grabbing a header works, but it will require our headers to be in consistent order:
+    Regex /X-B3-Spanid: (?<b3_spanid>\S+).*^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]*) (?<ident>[^ ]+) \[(?<ptype>[^ ]+)\] - (?<message>.*)/m
     Time_Key time
     Time_Format %Y-%m-%dT%H:%M:%S.%L%z
     Time_Keep On
-
-[PARSER]
-    Name post-with-syslog-rfc5424
-    Format regex
-    # Regex       /.*\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*?)\]|-)) (?<message>.+).*/m
-    Regex /\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-a0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*?)\]|-)) (?<message>.*)/m
-    # Time_Key time
-    # Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    # Time_Keep On

--- a/scripts/parse_http_headers.lua
+++ b/scripts/parse_http_headers.lua
@@ -1,0 +1,14 @@
+-- Convert the http_headers field (block of text) to a table of key:value pairs
+function parse_http_headers(tag, timestamp, record)
+    local header_string	= record["http_headers"]
+    local headers = {}
+    for header_name, val in string.gmatch(header_string, "(%S+): ([^\r\n]+)") do    
+       -- fluent-bit keys cannot include dashes. Let's coerce to lowercase as well.
+       local safe_name = string.lower(string.gsub(header_name, '-', '_'))
+       headers[safe_name] = val
+    end
+    record["http_headers"] = headers
+    -- 2 leaves timestamp unchanged    
+    return 2, timestamp, record
+end
+

--- a/scripts/parse_keys_with_eq_pairs.lua
+++ b/scripts/parse_keys_with_eq_pairs.lua
@@ -3,9 +3,8 @@
 KEYS_TO_PARSE = {"tags", "gauge"}
 
 -- Splits a string of foo="bar" pairs and makes parsable json out of it. 
-function parse_tags_with_eq_pairs(tag, timestamp, record)
+function parse_keys_with_eq_pairs(tag, timestamp, record)
     for k, v in pairs(KEYS_TO_PARSE) do
-
         if (record[v] ~= nil) then 
             record[v] = eq_pairs_to_json_string(record[v])
 	end

--- a/scripts/parse_tags_with_eq_pairs.lua
+++ b/scripts/parse_tags_with_eq_pairs.lua
@@ -1,0 +1,23 @@
+-- This parser is just a proof-of-concept. 
+
+KEYS_TO_PARSE = {"tags", "gauge"}
+
+-- Splits a string of foo="bar" pairs and makes parsable json out of it. 
+function parse_tags_with_eq_pairs(tag, timestamp, record)
+    for k, v in pairs(KEYS_TO_PARSE) do
+
+        if (record[v] ~= nil) then 
+            record[v] = eq_pairs_to_json_string(record[v])
+	end
+    end
+     -- 2 leaves timestamp unchanged
+    return 2, timestamp, record
+end
+
+function eq_pairs_to_json_string(orig_string)
+    local new_string = string.gsub(orig_string, "(%S+)=(%S+)", "\"%1\":%2,")
+    -- trim off that last , and add curly braces around: 
+    new_string = string.gsub(new_string, "(.+),$", "{%1}")
+    return new_string
+end    
+

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/home/vcap/deps/0/apt/opt/fluent-bit/bin/fluent-bit -P ${PORT} -c fluentbit.conf
+/home/vcap/deps/0/apt/opt/fluent-bit/bin/fluent-bit -c fluentbit.conf


### PR DESCRIPTION
The parsing here does a nice job on the "tags" and "gauge" parts of the messages, at least as far as feeding them into New Relic is concerned. This provides log data that should be easy to set up alerting on based on CPU, memory, and disk usage.

The names I used for some of the keys would be worth a review! 

The parser expressions and lua filters are probably a bit fragile at this stage. 

Here's a screenshot of part of what NR gets, restricted to records where gauge.name was populated. 

![NR_gauge_name](https://github.com/GSA-TTS/cg-logshipper/assets/35591/3fea1072-6a08-4e26-897e-3d26b9a6629b)
