### PR TITLE
Add HTTP proxy, basic auth, minor parser improvements

### DIFF
--- a/.profile
+++ b/.profile
@@ -2,7 +2,7 @@
 
 # Uses jq to:
 # - extract New Relic config from VCAP_SERVICES and set env vars
-# - [TODO] extract S3 bucket params from a bound service in VCAP_SERVICES and set env vars
+# - extract S3 bucket params from a bound service in VCAP_SERVICES and set env vars
 # - Save user/password for HTTP auth to a file for nginx basic auth.
 
 export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LICENSE_KEY")"

--- a/.profile
+++ b/.profile
@@ -3,13 +3,16 @@
 # Uses jq to:
 # - extract New Relic config from VCAP_SERVICES and set env vars
 # - [TODO] extract S3 bucket params from a bound service in VCAP_SERVICES and set env vars
+# - Save user/password for HTTP auth to a file for nginx basic auth.
 
 export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LICENSE_KEY")"
 export NEW_RELIC_LOGS_ENDPOINT="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LOGS_ENDPOINT")"
 
+HTTP_USER="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "cg-logshipper-creds" ".[][] | select(.name == \$service_name) | .credentials.HTTP_USER")"
+HTTP_PASS="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "cg-logshipper-creds" ".[][] | select(.name == \$service_name) | .credentials.HTTP_PASS")"
+HTTP_PASS_CRYPT="$(openssl passwd ${HTTP_PASS})"
+echo "${HTTP_USER}:${HTTP_PASS_CRYPT}" > /home/vcap/app/http_creds
+chmod 600 /home/vcap/app/http_creds
+
 # Add HTTPS_PROXY (example):
 export HTTPS_PROXY=$PROXYROUTE
-
-# Include certs for proxy (turned out not to be needed for New Relic output plugin):
-# export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
-# export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt

--- a/.profile
+++ b/.profile
@@ -8,6 +8,11 @@
 export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LICENSE_KEY")"
 export NEW_RELIC_LOGS_ENDPOINT="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LOGS_ENDPOINT")"
 
+export BUCKET_NAME="$(echo "$VCAP_SERVICES" | jq --raw-output '.["s3"][]? | select(.name == "log-storage") | .credentials.bucket')"
+export AWS_DEFAULT_REGION="$(echo "$VCAP_SERVICES" | jq --raw-output '.["s3"][]? | select(.name == "log-storage") | .credentials.region')"
+export AWS_ACCESS_KEY_ID="$(echo "$VCAP_SERVICES" | jq --raw-output '.["s3"][]? | select(.name == "log-storage") | .credentials.access_key_id')"
+export AWS_SECRET_ACCESS_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output '.["s3"][]? | select(.name == "log-storage") | .credentials.secret_access_key')"
+
 HTTP_USER="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "cg-logshipper-creds" ".[][] | select(.name == \$service_name) | .credentials.HTTP_USER")"
 HTTP_PASS="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "cg-logshipper-creds" ".[][] | select(.name == \$service_name) | .credentials.HTTP_PASS")"
 HTTP_PASS_CRYPT="$(openssl passwd ${HTTP_PASS})"

--- a/README.md
+++ b/README.md
@@ -13,35 +13,82 @@ To accomplish this for systems hosted on cloud.gov, the code in this repository 
 
 ## Deploying
 
-1. Create a user-provided service with your New Relic license key
+Note: Instructions currently assume you will ship to _both_ New Relic and S3. Better configuration is TODO.
+
+All of the following steps take place in the same cf space where the logshipper will reside. Commands in .profile are looking for specific service names, so use the names suggested (or edit .profile).
+
+1. Create a user-provided service "newrelic-creds" with your New Relic license key
     ```sh
     cf create-user-provided-service newrelic-creds -p '{"NEW_RELIC_LICENSE_KEY":"[your key]", "NEW_RELIC_LOGS_ENDPOINT": "[your endpoint]"}'
     ```
     NB: Use the correct NEW_RELIC_LOGS_ENDPOINT for your account. Refer to https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#endpoint
 
-2. Push the application
+2. Create an s3 bucket "log-storage" to receive log files:
+    ```sh
+    cf create-service s3 basic log-storage
+    ```
+
+3. Create a user-provided service "cg-logshipper-creds" to provide HTTP basic auth creds. These will be provided to the logshipper by the service; you will also need to supply them to the log drain service(s) as part of the URL:
+    ```sh
+    cf create-user-provided-service cg-logshipper-creds -p '{"HTTP_USER": "Some_username_you_provide", "HTTP_PASS": "Some_password"}'
+    ```
+
+4. Push the application
     ```sh
     cf push
     ```
-3. Check the logs to see if there were any problems
+
+5. Bind the services to the app (now that it exists) and restage it:
+    ```sh
+    cf bind-service fluentbit-drain newrelic-creds
+    cf bind-service fluentbit-drain cg-logshipper-creds
+    cf bind-service fluentbit-drain log-storage
+    cf restage fluentbit-drain
+    ```
+
+6. Check the logs to see if there were any problems
     ```sh
     cf logs fluentbit-drain --recent
     ```
+
+7. If you are using an egress proxy, set the $HTTPS_PROXY variable. (TODO; current .profile assumes a $PROXYROUTE in the app's env)
+
+At this point you should have a running app, but nothing is sending logs to it.
+
+## Setting up a log drain service
+
+Set up one or more log drain services to transmit files to the logshipper app. You will need the basic auth credentials you generated while deploying the app, as well as the URL of the fluentbit-drain app.
+
+The log drain service should be in the space with the app(s) from which you want to collect logs. The name of the log drain service doesn't matter; "log-drain-to-fluentbit" is just an example.
+
+The `drain-type=all` query parameter tells Cloud Foundry to send both logs and metrics, which is probably what you want. See [Cloud Foundry's log management documentation](https://docs.cloudfoundry.org/devguide/services/log-management.html#:~:text=Where%20%60DRAIN%2DTYPE%2DVALUE%60%20is%20one%20of%20the%20following%3A).
+
+1. Set up a log drain service:
+    ```sh
+    cf create-user-provided-service log-drain-to-fluentbit -l 'https://Some_username_you_provide:Some_password@fluentbit-drain-some-random-words.app.cloud.gov/?drain-type=all'
+    ```
+
+2. Bind the log drain service to the app(s):
+    ```sh
+    cf bind-service hello-world-app log-drain-to-fluentbit
+    cf bind-service another-app log-drain-to-fluentbit
+    ```
+
+Logs should begin to flow after a short delay. You will be able to see traffic hitting the fluent-bit app's web server. The logshipper uses New Relic's Logs API to transfer individual log entries as it processes them. For s3, it batches log entries into files that are transferred to the s3 bucket when they reach a certain size (default 50M) or when the upload timeout period (default 10 minutes) has passed.
 
 ## Status
 
 - Can run `cf push` and see fluentbit running with the supplied configuration
 - We have tested with a legit NR license key and seen logs appearing in NR.
 - Input configured to accept logs from a cf log-drain service.
-- Look for and use `HTTPS_PROXY` for egress connections (New Relic's plugin provides this) 
+- Web server accepts HTTP request and proxies them to fluent-bit (using TCP).
+  - Web server requires HTTP basic auth.
+- Look for and use `HTTPS_PROXY` for egress connections (New Relic's plugin provides this).
 
 ### TODO
 
-- Add a web server. We're currently accepting HTTP requests but not sending a response, which is rude and will probably lead to excessive open connections. Web server needs to listen on ${PORT}, pipe data to fluentbit, and send a response (not necessarily in that order). 
-  - Restrict incoming traffic by credentials (basic auth)
-  - Restrict to cloud.gov egress ranges (52.222.122.97/32, 52.222.123.172/32)? 
-- Futher improve the parsing of logs -- handle or include examples for nginx, apache log messages
-- Configure the app to recognize a bound S3 bucket service in VCAP_SERVICES, and ship logs there as well
+- Maybe restrict incoming traffic to cloud.gov egress ranges (52.222.122.97/32, 52.222.123.172/32)?
+- Document parsing of logs, maybe add examples for parsing common formats.
 - Port over all the [`datagov-logstack`](https://github.com/GSA/datagov-logstack) utility scripts for registering drains on apps/spaces
 - Add tests?
 

--- a/buildpack.yml
+++ b/buildpack.yml
@@ -1,0 +1,2 @@
+---
+dist: openresty

--- a/fluentbit.conf
+++ b/fluentbit.conf
@@ -1,6 +1,6 @@
 [SERVICE]
     flush        1
-    log_level    trace # TODO change to info when all is working well
+    log_level    info
     parsers_file parsers.conf
     parsers_file /home/vcap/deps/0/apt/etc/fluent-bit/parsers.conf
     plugins_File plugins.conf

--- a/fluentbit.conf
+++ b/fluentbit.conf
@@ -15,18 +15,27 @@
     port 8888
     format none
 
-# # Ship to s3:
-# #
-# # TODO:
-# #  - Refer to extracted env vars in the config below
-# [OUTPUT]
-#      Name s3
-#      Match *
-#      bucket your-bucket
-#      region us-east-1
-#      store_dir /home/ec2-user/buffer
-#      total_file_size 50M
-#      upload_timeout 10m
+# Ship to s3:
+#
+# TODO:
+#  - Refer to extracted env vars in the config below
+[OUTPUT]
+    Name s3
+    Match *
+    bucket ${BUCKET_NAME}
+    region ${AWS_DEFAULT_REGION}
+    json_date_key time
+    json_date_format iso8601
+    # TODO: will fluent-bit reliably upload partial data upon shutdown? Persistent storage may be desirable.
+    store_dir /tmp/fluent-bit/s3
+    total_file_size 50M
+    upload_timeout 10m
+    # TODO: modify s3_key_format -- by app?
+    # 2023-09-22T18:35:47.45-0700 [APP/PROC/WEB/SIDECAR/FLUENTBIT/0] ERR [2023/09/23 01:35:47] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tcp.1/2023/09/23/01/25/39-object7fe2lXYa
+    s3_key_format /fluent-bit-logs/$TAG/%Y/%m/%d/%H/%M/%S
+    retry_limit 5
+    # TODO: do we care about data ordering?
+    preserve_data_ordering On
 
 # Ship to New Relic:
 [OUTPUT]

--- a/fluentbit.conf
+++ b/fluentbit.conf
@@ -12,7 +12,7 @@
 
 [INPUT]
     name tcp
-    port ${PORT}
+    port 8888
     format none
     # TODO: We are accepting HTTP requests but not closing them. This helps but more research is needed.
     # TODO: We're going to need an http server.

--- a/fluentbit.conf
+++ b/fluentbit.conf
@@ -1,6 +1,6 @@
 [SERVICE]
     flush        1
-    log_level    trace
+    log_level    trace # TODO change to info when all is working well
     parsers_file parsers.conf
     parsers_file /home/vcap/deps/0/apt/etc/fluent-bit/parsers.conf
     plugins_File plugins.conf
@@ -14,10 +14,6 @@
     name tcp
     port 8888
     format none
-    # TODO: We are accepting HTTP requests but not closing them. This helps but more research is needed.
-    # TODO: We're going to need an http server.
-    net.io_timeout              1
-
 
 # Uncomment to ship to s3
 #
@@ -44,14 +40,7 @@
     name stdout
     match *
 
-
 ### Filters run in order of appearance ###
-# Combine multiple (headers + body)of an HTTP POST request into a single record.
-[FILTER]
-    name multiline
-    match tcp.*
-    multiline.key_content log
-    multiline.parser combine-http-post
 
 # Initial pass at parsing the body of the request.
 [FILTER]
@@ -87,11 +76,3 @@
     time_as_table On
     script scripts/parse_keys_with_eq_pairs.lua
     call parse_keys_with_eq_pairs
-
-# Parse the http headers into pairs.
-[FILTER]
-    name lua
-    match tcp.*
-    time_as_table On
-    script scripts/parse_http_headers.lua
-    call parse_http_headers

--- a/fluentbit.conf
+++ b/fluentbit.conf
@@ -16,9 +16,6 @@
     format none
 
 # Ship to s3:
-#
-# TODO:
-#  - Refer to extracted env vars in the config below
 [OUTPUT]
     Name s3
     Match *
@@ -26,13 +23,11 @@
     region ${AWS_DEFAULT_REGION}
     json_date_key time
     json_date_format iso8601
-    # TODO: will fluent-bit reliably upload partial data upon shutdown? Persistent storage may be desirable.
     store_dir /tmp/fluent-bit/s3
     total_file_size 50M
     upload_timeout 10m
     # TODO: modify s3_key_format -- by app?
-    # 2023-09-22T18:35:47.45-0700 [APP/PROC/WEB/SIDECAR/FLUENTBIT/0] ERR [2023/09/23 01:35:47] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tcp.1/2023/09/23/01/25/39-object7fe2lXYa
-    s3_key_format /fluent-bit-logs/$TAG/%Y/%m/%d/%H/%M/%S
+    s3_key_format /fluent-bit-logs/%Y/%m/%d/%H/%M/%S
     retry_limit 5
     # TODO: do we care about data ordering?
     preserve_data_ordering On

--- a/fluentbit.conf
+++ b/fluentbit.conf
@@ -15,10 +15,10 @@
     port 8888
     format none
 
-# Uncomment to ship to s3
-#
-# TODO:
-#  - Refer to extracted env vars in the config below
+# # Ship to s3:
+# #
+# # TODO:
+# #  - Refer to extracted env vars in the config below
 # [OUTPUT]
 #      Name s3
 #      Match *
@@ -28,17 +28,17 @@
 #      total_file_size 50M
 #      upload_timeout 10m
 
-# Uncomment to ship to New Relic
-# [OUTPUT]
-#     Name newrelic
-#     Match *
-#     licenseKey ${NEW_RELIC_LICENSE_KEY}
-#     endpoint ${NEW_RELIC_LOGS_ENDPOINT}
-
-# Uncomment to see the parsed messages in the logshipper's logs:
+# Ship to New Relic:
 [OUTPUT]
-    name stdout
-    match *
+    Name newrelic
+    Match *
+    licenseKey ${NEW_RELIC_LICENSE_KEY}
+    endpoint ${NEW_RELIC_LOGS_ENDPOINT}
+
+# # Uncomment to see the parsed messages in the logshipper's logs:
+# [OUTPUT]
+#     name stdout
+#     match *
 
 ### Filters run in order of appearance ###
 
@@ -66,6 +66,22 @@
     match tcp.*
     key_name message
     parser extract-tags
+    reserve_data On
+    preserve_key On
+
+[FILTER]
+    name parser
+    match tcp.*
+    key_name message
+    parser extract-remainder
+    reserve_data On
+    preserve_key On
+
+[FILTER]
+    name parser
+    match tcp.*
+    key_name remainder
+    parser extract-json-object-from-remainder
     reserve_data On
     preserve_key On
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,6 +8,7 @@ applications:
   services:
   - newrelic-creds
   - cg-logshipper-creds
+  - log-storage
   sidecars:
     - name: fluentbit
       process_types: [ 'web' ]

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,7 +6,8 @@ applications:
   - https://github.com/cloudfoundry/apt-buildpack
   - nginx_buildpack
   services:
-  - newrelic-creds  
+  - newrelic-creds
+  - cg-logshipper-creds
   sidecars:
     - name: fluentbit
       process_types: [ 'web' ]

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,8 +4,11 @@ applications:
   memory: 256M
   buildpacks:
   - https://github.com/cloudfoundry/apt-buildpack
-  - binary_buildpack
-  command: ./start.sh
-  health-check-type: process
+  - nginx_buildpack
   services:
   - newrelic-creds  
+  sidecars:
+    - name: fluentbit
+      process_types: [ 'web' ]
+      command: /home/vcap/deps/0/apt/opt/fluent-bit/bin/fluent-bit -c fluentbit.conf
+    

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,27 +9,44 @@ http {
   log_format cloudfoundry 'NginxLog "$request" $status $body_bytes_sent';
   access_log /dev/stdout cloudfoundry;
   default_type application/octet-stream;
-  sendfile on;
 
   tcp_nopush on;
   keepalive_timeout 30;
-  port_in_redirect off; # Ensure that redirects don't include the internal container PORT - 8080
+  port_in_redirect off; # Ensure that redirects don't include the internal container PORT
 
   server {
     listen {{port}};
-    root public;
-    index index.html index.htm Default.htm;
-    # location / {
-    #   proxy_pass http://127.0.0.1:8888;
-    # }
-    location / {
-        default_type text/html;
-        more_set_headers "openresty-test: hello!";
-        content_by_lua '
-            os.execute("echo hello STDERR")
-            ngx.say("<p>hello, world</p>")
-        ';
-    }
 
+    location / {
+
+        # client_body_buffer_size and client_max_body_size should match, to
+        # ensure the $request_body will have data.
+        # (8K is the default buffer size, and probably more than enough for log messages.)
+        client_body_buffer_size 8K;
+        client_max_body_size 8K;
+        lua_need_request_body on;
+
+        if ($request_method = POST) {
+          content_by_lua_block {
+             local sock = ngx.socket.tcp()
+             local ok, err = sock:connect("127.0.0.1", 8888)
+             if not ok then
+                ngx.log(ngx.ERR, err)
+                return ngx.exit(ngx.HTTP_BAD_GATEWAY)
+             end
+             local bytes, err = sock:send(ngx.var.request_body)
+             sock:close()
+             if err then
+                ngx.log(ngx.ERR, err)
+                return ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
+             end
+             return ngx.exit(ngx.HTTP_CREATED)
+          }
+        }
+        if ($request_method != POST) {
+          # We don't want anything but POSTs.
+          return 400;
+        }
+    }
   }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,34 @@
+worker_processes 1;
+daemon off;
+
+error_log stderr;
+events { worker_connections 1024; }
+
+http {
+  charset utf-8;
+  log_format cloudfoundry 'NginxLog "$request" $status $body_bytes_sent';
+  access_log /dev/stdout cloudfoundry;
+  default_type application/octet-stream;
+  sendfile on;
+
+  tcp_nopush on;
+  keepalive_timeout 30;
+  port_in_redirect off; # Ensure that redirects don't include the internal container PORT - 8080
+
+  server {
+    listen {{port}};
+    root public;
+    index index.html index.htm Default.htm;
+    # location / {
+    #   proxy_pass http://127.0.0.1:8888;
+    # }
+    location / {
+        default_type text/html;
+        more_set_headers "openresty-test: hello!";
+        content_by_lua '
+            ngx.say("<p>hello, world</p>")
+        ';
+    }
+
+  }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -26,6 +26,7 @@ http {
         default_type text/html;
         more_set_headers "openresty-test: hello!";
         content_by_lua '
+            os.execute("echo hello STDERR")
             ngx.say("<p>hello, world</p>")
         ';
     }

--- a/nginx.conf
+++ b/nginx.conf
@@ -10,6 +10,9 @@ http {
   access_log /dev/stdout cloudfoundry;
   default_type application/octet-stream;
 
+  auth_basic access_required;
+  auth_basic_user_file /home/vcap/app/http_creds;
+
   tcp_nopush on;
   keepalive_timeout 30;
   port_in_redirect off; # Ensure that redirects don't include the internal container PORT

--- a/parsers.conf
+++ b/parsers.conf
@@ -14,7 +14,7 @@
     # rules |   state name  | regex pattern                  | next state
     # ------|---------------|--------------------------------------------
     rule      "start_state"   "/^POST \S+ HTTP\/1\.1\r/"       "cont"
-    rule      "cont"          "/.*/"                         "cont"
+    rule      "cont"          "/.*/"                           "cont"
 
 
 [PARSER]

--- a/parsers.conf
+++ b/parsers.conf
@@ -16,11 +16,10 @@
     rule      "start_state"   "/^POST \S+ HTTP\/1\.1\r/"       "cont"
     rule      "cont"          "/.*/"                           "cont"
 
-
 [PARSER]
     Name post-with-syslog
     Format regex
-    Regex /(?<http_headers>.*)^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]*) (?<ident>[^ ]+) \[(?<ptype>[^ ]+)\] - (?<message>.*)/m
+    Regex /^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]*) (?<ident>[^ ]+) \[(?<ptype>[^ ]+)\] - (?<message>.*)/m
     Time_Key time
     Time_Format %Y-%m-%dT%H:%M:%S.%L%z
     Time_Keep On
@@ -34,6 +33,18 @@
     Name extract-tags
     Format regex
     Regex /\[tags@\d+ (?<tags>[^\]]+)/m
+
+[PARSER]
+    # "remainder" is additional log data you might want to write your own parsers for.
+    Name extract-remainder
+    Format regex
+    Regex /(\[\S+@\d+ [^\]]+\])+\s*(?<remainder>.+)/m
+
+[PARSER]
+    # Extract probable-json object from remainder. Experimental!
+    Name extract-json-object-from-remainder
+    Format regex
+    Regex /\d{2}:\d{2}:\d{2} (?<application_ident>\S+)\s+\|\s+(?<application_log>\{.*\})\s*$/m
 
 [PARSER]
     Name string-to-json

--- a/parsers.conf
+++ b/parsers.conf
@@ -38,7 +38,7 @@
     # "remainder" is additional log data you might want to write your own parsers for.
     Name extract-remainder
     Format regex
-    Regex /(\[\S+@\d+ [^\]]+\])+\s*(?<remainder>.+)/m
+    Regex /(\[(tags|gauge)@\d+ [^\]]+\])+\s*(?<remainder>.+)/m
 
 [PARSER]
     # Extract probable-json object from remainder. Experimental!


### PR DESCRIPTION
Adds a nginx front-end, so that we're actually speaking HTTP with the cf drain. Includes HTTP basic auth front end. 

Small changes to parsers: 
 - removed http_headers, because the front-end proxy strips those out (which is fine) 
 - extracts the part of the log message that is neither "tags" nor "gauge" into "remainder"
 - tries to pull a json object out of that remainder (rough experiment)