### PR TITLE
Parsing tweaks: retain entire log message as "raw_message" and output former "remainder" as "message" 

### DIFF
--- a/fluentbit.conf
+++ b/fluentbit.conf
@@ -52,8 +52,13 @@
     match tcp.*
     key_name log
     parser post-with-syslog
-    reserve_data Off
+    reserve_data On
     preserve_key On
+
+[FILTER]
+    name modify
+    match tcp.*
+    Rename log raw_message
 
 # Further filter of the already-extracted fields
 [FILTER]
@@ -79,13 +84,14 @@
     key_name message
     parser extract-remainder
     reserve_data On
-    preserve_key On
+    preserve_key Off
 
+# TODO: does this do anything?
 [FILTER]
     name parser
     match tcp.*
-    key_name remainder
-    parser extract-json-object-from-remainder
+    key_name message
+    parser extract-json-object-from-message
     reserve_data On
     preserve_key On
 

--- a/parsers.conf
+++ b/parsers.conf
@@ -38,11 +38,11 @@
     # "remainder" is additional log data you might want to write your own parsers for.
     Name extract-remainder
     Format regex
-    Regex /(\[(tags|gauge)@\d+ [^\]]+\])+\s*(?<remainder>.+)/m
+    Regex /(\[(tags|gauge)@\d+ [^\]]+\])+\s*(?<message>.+)/m
 
 [PARSER]
     # Extract probable-json object from remainder. Experimental!
-    Name extract-json-object-from-remainder
+    Name extract-json-object-from-message
     Format regex
     Regex /\d{2}:\d{2}:\d{2} (?<application_ident>\S+)\s+\|\s+(?<application_log>\{.*\})\s*$/m
 


### PR DESCRIPTION
Added a "raw_message" field for the entire log message received by the logshipper, and renamed the "remainder" field to "message." 

This is based on initial feedback from @jacobaaronyeager (specifically, the "raw_message" name) and the fact that "message" is the default search field for New Relic.