### PR TITLE
Update .profile to find tags instead of specific service names

### DIFF
--- a/.profile
+++ b/.profile
@@ -5,8 +5,8 @@
 # - extract S3 bucket params from a bound service in VCAP_SERVICES and set env vars
 # - Save user/password for HTTP auth to a file for nginx basic auth.
 
-export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("newrelic")) | .credentials.NEW_RELIC_LICENSE_KEY')"
-export NEW_RELIC_LOGS_ENDPOINT="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("newrelic")) | .credentials.NEW_RELIC_LOGS_ENDPOINT')"
+export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("newrelic-creds")) | .credentials.NEW_RELIC_LICENSE_KEY')"
+export NEW_RELIC_LOGS_ENDPOINT="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("newrelic-creds")) | .credentials.NEW_RELIC_LOGS_ENDPOINT')"
 
 export BUCKET_NAME="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.bucket')"
 export AWS_DEFAULT_REGION="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.region')"

--- a/.profile
+++ b/.profile
@@ -5,16 +5,16 @@
 # - extract S3 bucket params from a bound service in VCAP_SERVICES and set env vars
 # - Save user/password for HTTP auth to a file for nginx basic auth.
 
-export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("newrelic")) | .credentials.NEW_RELIC_LICENSE_KEY')"
-export NEW_RELIC_LOGS_ENDPOINT="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("newrelic")) | .credentials.NEW_RELIC_LOGS_ENDPOINT')"
+export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("logshipper")) | .credentials.NEW_RELIC_LICENSE_KEY')"
+export NEW_RELIC_LOGS_ENDPOINT="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("logshipper")) | .credentials.NEW_RELIC_LOGS_ENDPOINT')"
 
-export BUCKET_NAME="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.bucket')"
-export AWS_DEFAULT_REGION="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.region')"
-export AWS_ACCESS_KEY_ID="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.access_key_id')"
-export AWS_SECRET_ACCESS_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.secret_access_key')"
+export BUCKET_NAME="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper")) | .credentials.bucket')"
+export AWS_DEFAULT_REGION="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper")) | .credentials.region')"
+export AWS_ACCESS_KEY_ID="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper")) | .credentials.access_key_id')"
+export AWS_SECRET_ACCESS_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper")) | .credentials.secret_access_key')"
 
-HTTP_USER="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("logshipper-creds")) | .credentials.HTTP_USER')"
-HTTP_PASS="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("logshipper-creds")) | .credentials.HTTP_PASS')"
+HTTP_USER="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("logshipper")) | .credentials.HTTP_USER')"
+HTTP_PASS="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("logshipper")) | .credentials.HTTP_PASS')"
 HTTP_PASS_CRYPT="$(openssl passwd ${HTTP_PASS})"
 echo "${HTTP_USER}:${HTTP_PASS_CRYPT}" > /home/vcap/app/http_creds
 chmod 600 /home/vcap/app/http_creds

--- a/.profile
+++ b/.profile
@@ -5,16 +5,16 @@
 # - extract S3 bucket params from a bound service in VCAP_SERVICES and set env vars
 # - Save user/password for HTTP auth to a file for nginx basic auth.
 
-export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LICENSE_KEY")"
-export NEW_RELIC_LOGS_ENDPOINT="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LOGS_ENDPOINT")"
+export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("newrelic")) | .credentials.NEW_RELIC_LICENSE_KEY')"
+export NEW_RELIC_LOGS_ENDPOINT="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("newrelic")) | .credentials.NEW_RELIC_LOGS_ENDPOINT')"
 
-export BUCKET_NAME="$(echo "$VCAP_SERVICES" | jq --raw-output '.["s3"][]? | select(.name == "log-storage") | .credentials.bucket')"
-export AWS_DEFAULT_REGION="$(echo "$VCAP_SERVICES" | jq --raw-output '.["s3"][]? | select(.name == "log-storage") | .credentials.region')"
-export AWS_ACCESS_KEY_ID="$(echo "$VCAP_SERVICES" | jq --raw-output '.["s3"][]? | select(.name == "log-storage") | .credentials.access_key_id')"
-export AWS_SECRET_ACCESS_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output '.["s3"][]? | select(.name == "log-storage") | .credentials.secret_access_key')"
+export BUCKET_NAME="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.bucket')"
+export AWS_DEFAULT_REGION="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.region')"
+export AWS_ACCESS_KEY_ID="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.access_key_id')"
+export AWS_SECRET_ACCESS_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.secret_access_key')"
 
-HTTP_USER="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "cg-logshipper-creds" ".[][] | select(.name == \$service_name) | .credentials.HTTP_USER")"
-HTTP_PASS="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "cg-logshipper-creds" ".[][] | select(.name == \$service_name) | .credentials.HTTP_PASS")"
+HTTP_USER="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("logshipper-creds")) | .credentials.HTTP_USER')"
+HTTP_PASS="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("logshipper-creds")) | .credentials.HTTP_PASS')"
 HTTP_PASS_CRYPT="$(openssl passwd ${HTTP_PASS})"
 echo "${HTTP_USER}:${HTTP_PASS_CRYPT}" > /home/vcap/app/http_creds
 chmod 600 /home/vcap/app/http_creds

--- a/.profile
+++ b/.profile
@@ -5,16 +5,16 @@
 # - extract S3 bucket params from a bound service in VCAP_SERVICES and set env vars
 # - Save user/password for HTTP auth to a file for nginx basic auth.
 
-export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("logshipper")) | .credentials.NEW_RELIC_LICENSE_KEY')"
-export NEW_RELIC_LOGS_ENDPOINT="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("logshipper")) | .credentials.NEW_RELIC_LOGS_ENDPOINT')"
+export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("newrelic")) | .credentials.NEW_RELIC_LICENSE_KEY')"
+export NEW_RELIC_LOGS_ENDPOINT="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("newrelic")) | .credentials.NEW_RELIC_LOGS_ENDPOINT')"
 
-export BUCKET_NAME="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper")) | .credentials.bucket')"
-export AWS_DEFAULT_REGION="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper")) | .credentials.region')"
-export AWS_ACCESS_KEY_ID="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper")) | .credentials.access_key_id')"
-export AWS_SECRET_ACCESS_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper")) | .credentials.secret_access_key')"
+export BUCKET_NAME="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.bucket')"
+export AWS_DEFAULT_REGION="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.region')"
+export AWS_ACCESS_KEY_ID="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.access_key_id')"
+export AWS_SECRET_ACCESS_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.secret_access_key')"
 
-HTTP_USER="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("logshipper")) | .credentials.HTTP_USER')"
-HTTP_PASS="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("logshipper")) | .credentials.HTTP_PASS')"
+HTTP_USER="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("logshipper-creds")) | .credentials.HTTP_USER')"
+HTTP_PASS="$(echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("logshipper-creds")) | .credentials.HTTP_PASS')"
 HTTP_PASS_CRYPT="$(openssl passwd ${HTTP_PASS})"
 echo "${HTTP_USER}:${HTTP_PASS_CRYPT}" > /home/vcap/app/http_creds
 chmod 600 /home/vcap/app/http_creds

--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ To accomplish this for systems hosted on cloud.gov, the code in this repository 
 
 Note: Instructions currently assume you will ship to _both_ New Relic and S3. Better configuration is TODO.
 
-All of the following steps take place in the same cf space where the logshipper will reside. Commands in .profile are looking for specific service names, so use the names suggested (or edit .profile).
+All of the following steps take place in the same cf space where the logshipper will reside.
+
+Commands in .profile look for specific tags. The names of the specific services can be unique, without impacting the `.profile`. The specific tags for the services are:
+- cg-logshipper-creds = `logshipper-creds`
+- log-storage = `logshipper-s3`
+- newrelic-creds = `newrelic`
 
 1. Create a user-provided service "newrelic-creds" with your New Relic license key
     ```sh

--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ Current Supported Tags:
 
 1. Create a user-provided service "newrelic-creds" with your New Relic license key
     ```sh
-    cf create-user-provided-service my-newrelic-credential-name -p '{"NEW_RELIC_LICENSE_KEY":"[your key]", "NEW_RELIC_LOGS_ENDPOINT": "[your endpoint]"}'
+    cf create-user-provided-service my-newrelic-credential-name -p '{"NEW_RELIC_LICENSE_KEY":"[your key]", "NEW_RELIC_LOGS_ENDPOINT": "[your endpoint]"}' -t "newrelic-creds"
     ```
     NB: Use the correct NEW_RELIC_LOGS_ENDPOINT for your account. Refer to https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#endpoint
 
 2. Create an s3 bucket "log-storage" to receive log files:
     ```sh
-    cf create-service s3 basic my-s3-name
+    cf create-service s3 basic my-s3-name -t "logshipper-s3"
     ```
 
 3. Create a user-provided service "cg-logshipper-creds" to provide HTTP basic auth creds. These will be provided to the logshipper by the service; you will also need to supply them to the log drain service(s) as part of the URL:
     ```sh
-    cf create-user-provided-service my-logshipper-credential-name -p '{"HTTP_USER": "Some_username_you_provide", "HTTP_PASS": "Some_password"}'
+    cf create-user-provided-service my-logshipper-credential-name -p '{"HTTP_USER": "Some_username_you_provide", "HTTP_PASS": "Some_password"}' -t "logshipper-creds"
     ```
 
 4. Push the application

--- a/README.md
+++ b/README.md
@@ -17,10 +17,7 @@ Note: Instructions currently assume you will ship to _both_ New Relic and S3. Be
 
 All of the following steps take place in the same cf space where the logshipper will reside.
 
-Commands in .profile look for specific tags. The names of the specific services can be unique, without impacting the `.profile`. The specific tags for the services are:
-- cg-logshipper-creds = `logshipper-creds`
-- log-storage = `logshipper-s3`
-- newrelic-creds = `newrelic`
+Commands in .profile look for a specific tag of `logshipper`. The names of the specific services can be unique, without impacting the `.profile`.
 
 1. Create a user-provided service "newrelic-creds" with your New Relic license key
     ```sh

--- a/README.md
+++ b/README.md
@@ -24,18 +24,18 @@ Commands in .profile look for specific tags. The names of the specific services 
 
 1. Create a user-provided service "newrelic-creds" with your New Relic license key
     ```sh
-    cf create-user-provided-service newrelic-creds -p '{"NEW_RELIC_LICENSE_KEY":"[your key]", "NEW_RELIC_LOGS_ENDPOINT": "[your endpoint]"}'
+    cf create-user-provided-service my-newrelic-credential-name -p '{"NEW_RELIC_LICENSE_KEY":"[your key]", "NEW_RELIC_LOGS_ENDPOINT": "[your endpoint]"}'
     ```
     NB: Use the correct NEW_RELIC_LOGS_ENDPOINT for your account. Refer to https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#endpoint
 
 2. Create an s3 bucket "log-storage" to receive log files:
     ```sh
-    cf create-service s3 basic log-storage
+    cf create-service s3 basic my-s3-name
     ```
 
 3. Create a user-provided service "cg-logshipper-creds" to provide HTTP basic auth creds. These will be provided to the logshipper by the service; you will also need to supply them to the log drain service(s) as part of the URL:
     ```sh
-    cf create-user-provided-service cg-logshipper-creds -p '{"HTTP_USER": "Some_username_you_provide", "HTTP_PASS": "Some_password"}'
+    cf create-user-provided-service my-logshipper-credential-name -p '{"HTTP_USER": "Some_username_you_provide", "HTTP_PASS": "Some_password"}'
     ```
 
 4. Push the application
@@ -45,9 +45,9 @@ Commands in .profile look for specific tags. The names of the specific services 
 
 5. Bind the services to the app (now that it exists) and restage it:
     ```sh
-    cf bind-service fluentbit-drain newrelic-creds
-    cf bind-service fluentbit-drain cg-logshipper-creds
-    cf bind-service fluentbit-drain log-storage
+    cf bind-service fluentbit-drain my-newrelic-credential-name
+    cf bind-service fluentbit-drain my-s3-name
+    cf bind-service fluentbit-drain my-logshipper-credential-name
     cf restage fluentbit-drain
     ```
 
@@ -70,13 +70,13 @@ The `drain-type=all` query parameter tells Cloud Foundry to send both logs and m
 
 1. Set up a log drain service:
     ```sh
-    cf create-user-provided-service log-drain-to-fluentbit -l 'https://Some_username_you_provide:Some_password@fluentbit-drain-some-random-words.app.cloud.gov/?drain-type=all'
+    cf create-user-provided-service my-logdrain-name -l 'https://${HTTP_USER}:${HTTP_PASS}@fluentbit-drain-some-random-words.app.cloud.gov/?drain-type=all'
     ```
 
 2. Bind the log drain service to the app(s):
     ```sh
-    cf bind-service hello-world-app log-drain-to-fluentbit
-    cf bind-service another-app log-drain-to-fluentbit
+    cf bind-service hello-world-app my-logdrain-name
+    cf bind-service another-app my-logdrain-name
     ```
 
 Logs should begin to flow after a short delay. You will be able to see traffic hitting the fluent-bit app's web server. The logshipper uses New Relic's Logs API to transfer individual log entries as it processes them. For s3, it batches log entries into files that are transferred to the s3 bucket when they reach a certain size (default 50M) or when the upload timeout period (default 10 minutes) has passed.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ All of the following steps take place in the same cf space where the logshipper 
 
 Commands in .profile look for a specific tag in relation to the service. The names of the specific services can be unique, without impacting the `.profile`.
 Current Supported Tags:
-- The "newrelic-creds" user provided service = `newrelic`
+- The "newrelic-creds" user provided service = `newrelic-creds`
 - The "log-storage" s3 bucket = `logshipper-s3`
 - The "cg-logshipper-creds" user provided service = `logshipper-creds`
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ Note: Instructions currently assume you will ship to _both_ New Relic and S3. Be
 
 All of the following steps take place in the same cf space where the logshipper will reside.
 
-Commands in .profile look for a specific tag of `logshipper`. The names of the specific services can be unique, without impacting the `.profile`.
+Commands in .profile look for a specific tag in relation to the service. The names of the specific services can be unique, without impacting the `.profile`.
+Current Supported Tags:
+- The "newrelic-creds" user provided service = `newrelic`
+- The "log-storage" s3 bucket = `logshipper-s3`
+- The "cg-logshipper-creds" user provided service = `logshipper-creds`
 
 1. Create a user-provided service "newrelic-creds" with your New Relic license key
     ```sh


### PR DESCRIPTION
Following up from [PR #29](https://github.com/18F/terraform-cloudgov/pull/29) on the 18F terraform modules, which add tag support to the s3 bucket (and other modules), the following changes are proposed so that we can define a specific tag to get the values in the profile, instead of the name of the service.

This allows us to define a specific tag for the three required resources and keep the names of the services unique, while keeping the same functionality. 
Ex: `logshipper-s3` `logshipper-creds` & `newrelic-creds` 

The usecase for this proposal, is that we already have a service name `newrelic-creds` bound to our running application, and we cannot have 2 services sharing the same name. The terraform was already updated to add the credential `NEW_RELIC_LOGS_ENDPOINT`, so I left the tag generic to tag it as `newrelic`. The `newrelic-creds` that a consumer of the `cg-logshipper` may use by default does not implicitly mean it is used for logshipper. The same logic would be applied for an s3 module, where the s3 bucket may be tagged with `s3` & `logshipper-s3`, but since the s3 is dedicated to the consumption of the logs, rather than `newrelic-creds` service (which could be used globally) this seemed like the logical approach.

```bash
vcap@04f6127a-7e6a-4c5a-7b60-5f2b:~$ echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("newrelic-creds"))  | .credentials.NEW_RELIC_LICENSE_KEY'
b*************
vcap@04f6127a-7e6a-4c5a-7b60-5f2b:~$ echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("newrelic-creds")) | .credentials.NEW_RELIC_LOGS_ENDPOINT'
https://gov-log-api.newrelic.com/log/v1
vcap@04f6127a-7e6a-4c5a-7b60-5f2b:~$ echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.bucket'
c*************
vcap@04f6127a-7e6a-4c5a-7b60-5f2b:~$ echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.region'
us-gov-west-1
vcap@04f6127a-7e6a-4c5a-7b60-5f2b:~$ echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.access_key_id'
A*************
vcap@04f6127a-7e6a-4c5a-7b60-5f2b:~$ echo "$VCAP_SERVICES" | jq --raw-output '."s3" | .[] | select(.tags[] | contains("logshipper-s3")) | .credentials.secret_access_key'
ns*************
vcap@04f6127a-7e6a-4c5a-7b60-5f2b:~$ echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("logshipper-creds")) | .credentials.HTTP_USER'
56*************
vcap@04f6127a-7e6a-4c5a-7b60-5f2b:~$ echo "$VCAP_SERVICES" | jq --raw-output '."user-provided" | .[] | select(.tags[] | contains("logshipper-creds")) | .credentials.HTTP_PASS'
6**********
```

I am waiting for the FAC's `preview` environment to be free, so I can validate that tags are applied to the s3 resource via the 18F module, but will post those results when I can and move out of draft