### PR TITLE
Restrict access to the cloud.gov egress ranges (and localhost) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ Logs should begin to flow after a short delay. You will be able to see traffic h
 
 ### TODO
 
-- Maybe restrict incoming traffic to cloud.gov egress ranges (52.222.122.97/32, 52.222.123.172/32)?
 - Document parsing of logs, maybe add examples for parsing common formats.
 - Port over all the [`datagov-logstack`](https://github.com/GSA/datagov-logstack) utility scripts for registering drains on apps/spaces
 - Add tests?

--- a/nginx.conf
+++ b/nginx.conf
@@ -22,6 +22,8 @@ http {
   # First, re-set the $remote_addr from the X-Forwarded-For header.
   set_real_ip_from 127.0.0.1/32;
   set_real_ip_from 10.0.0.0/8;
+  set_real_ip_from 172.16.0.0/12;
+  set_real_ip_from 192.168.0.0/16;
   set_real_ip_from 52.222.122.97/32;
   set_real_ip_from 52.222.123.172/32;
   real_ip_header X-Forwarded-For;

--- a/nginx.conf
+++ b/nginx.conf
@@ -10,15 +10,42 @@ http {
   access_log /dev/stdout cloudfoundry;
   default_type application/octet-stream;
 
-  auth_basic access_required;
-  auth_basic_user_file /home/vcap/app/http_creds;
-
   tcp_nopush on;
   keepalive_timeout 30;
   port_in_redirect off; # Ensure that redirects don't include the internal container PORT
 
+  # Require basic auth.
+  auth_basic access_required;
+  auth_basic_user_file /home/vcap/app/http_creds;
+
+  # Additionally, require requests to be coming from within the cloud.gov network.
+  # First, re-set the $remote_addr from the X-Forwarded-For header.
+  set_real_ip_from 127.0.0.1/32;
+  set_real_ip_from 10.0.0.0/8;
+  set_real_ip_from 52.222.122.97/32;
+  set_real_ip_from 52.222.123.172/32;
+  real_ip_header X-Forwarded-For;
+  real_ip_recursive on;
+
+  # Based on that $remote_addr, set a variable we can check in the server block.
+  # (allow/deny directives should work, but for some reason I could not get them to work at any level --akf)
+  geo $ip_ok {
+      default 0;
+
+      # cloud.gov IPs and localhost (localhost for troubleshooting)
+      # https://cloud.gov/docs/management/static-egress/#cloudgov-egress-ranges
+      127.0.0.1/32       1;
+      52.222.122.97/32   1;
+      52.222.123.172/32  1;
+  }
+
   server {
     listen {{port}};
+
+    # IP address restriction (see http block)
+    if ( $ip_ok = 0 ) {
+	 return 403;
+    }
 
     location / {
 


### PR DESCRIPTION
This is pretty standard nginx config, but it's also obtuse (I think) and I'm happy to provide my understanding if desired. I went with the `geo` approach because `allow` and `deny` directives weren't working and I didn't see why. 

You should get a 400 status (bad request) for GETs, and a 403 (forbidden) if you make a POST request from outside of the allowed IP ranges. Missing or incorrect basic auth gets you a 401. So: 

From a shell on the app: 
`curl -i http://127.0.0.1:8080` -> 400  Bad Request
`curl -iX POST http://127.0.0.1:8080` -> 401 Authorization Required
`curl -iX POST http://[your-username]:[your-password]@127.0.0.1:8080` -> 201 Created 

From outside: 
`curl -i https://[your-logshipper-route].cloud.gov` -> 403 Forbidden
`curl -iX POST https://[your-logshipper-route].cloud.gov` -> 403 Forbidden * 

* I didn't know whether the Basic Auth or IP restriction would take precedence here; looks like it's IP restriction. 
