### PR TITLE
Update New Relic plugin to version 2.0.0

### DIFF
--- a/.profile
+++ b/.profile
@@ -20,4 +20,6 @@ echo "${HTTP_USER}:${HTTP_PASS_CRYPT}" > /home/vcap/app/http_creds
 chmod 600 /home/vcap/app/http_creds
 
 # Add HTTPS_PROXY (example):
-export HTTPS_PROXY=$PROXYROUTE
+if [ -n "$PROXYROUTE" ]; then
+    export HTTPS_PROXY=$PROXYROUTE
+fi

--- a/.profile
+++ b/.profile
@@ -20,6 +20,4 @@ echo "${HTTP_USER}:${HTTP_PASS_CRYPT}" > /home/vcap/app/http_creds
 chmod 600 /home/vcap/app/http_creds
 
 # Add HTTPS_PROXY (example):
-if [ -n "$PROXYROUTE" ]; then
-    export HTTPS_PROXY=$PROXYROUTE
-fi
+export HTTPS_PROXY=$PROXYROUTE

--- a/README.md
+++ b/README.md
@@ -108,11 +108,12 @@ You can supplement the default configuration by overwriting the files in the pro
 
 ### TODO
 
+- Turn on validateProxyCerts in New Relic output config and make the certs work
 - Document parsing of logs, maybe add examples for parsing common formats.
 - Port over all the [`datagov-logstack`](https://github.com/GSA/datagov-logstack) utility scripts for registering drains on apps/spaces
 - Add tests?
 - Add a --branch argument to the example under *Additional Configuration*, once we have a tagged release.
-- Change the method of getting PROXYROUTE to a user-provided service, rather than cf env. 
+
 
 ## Contributing
 

--- a/plugins.conf
+++ b/plugins.conf
@@ -1,2 +1,2 @@
 [PLUGINS]
-    Path /home/vcap/app/newrelic_output/out_newrelic-linux-amd64-1.17.3.so
+    Path /home/vcap/app/newrelic_output/out_newrelic-linux-amd64-2.0.0.so


### PR DESCRIPTION
Updates the New Relic output plugin to version 2.0.0: https://github.com/newrelic/newrelic-fluent-bit-output/releases/tag/v2.0.0

There is also an incidental update to the TODO list in the README.


I tested this by deploying this app first to my sandbox, and then to a space with restricted egress and a proxy, to verify that the new version of `newrelic-fluent-bit-output` successfully sends logs to New Relic both without and with a proxy server (`PROXYROUTE` env set). The manifest for the test had variant names for the app itself and the services, and the `fluent.bit.conf` file used the `dummy` input with multiple samples, plus the `stdout` OUTPUT because I wanted to see the logs. 

Note that although the timing of this PR was prompted by a vulnerability alert from New Relic (NR) and that NR says "bumping fluent bit version to 3.0.4," the plugin itself is largely independent of the fluent-bit version (probably thanks to fluent bit's backwards compatibility policy). The newrelic-fluent-bit-output repo (and src downloads) include Docker images that pull in fluent bit version 3.0.4, which could be used standalone to build a log shipper. We're installing fluent-bit via apt and getting the latest packaged version every time we start or restart an app. 