### PR TITLE
Increase client_body_buffer_size and client_max_body_size to 16K

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -53,9 +53,13 @@ http {
 
         # client_body_buffer_size and client_max_body_size should match, to
         # ensure the $request_body will have data.
-        # (8K is the default buffer size, and probably more than enough for log messages.)
-        client_body_buffer_size 8K;
-        client_max_body_size 8K;
+        #
+        # We started with 8K, which is the default buffer size, and learned that
+        # some POSTs were 9-10K. To check whether the size is too small for your
+        # application, look for log messages from your log-shipper app with the
+        # text "client intended to send too large body"
+        client_body_buffer_size 16K;
+        client_max_body_size 16K;
         lua_need_request_body on;
 
         if ($request_method = POST) {


### PR DESCRIPTION
Two systems using this code (are there more?) get occasional messages from the log-shipper that indicate that an 8K client_max_body_size is not, in fact, "more than enough for log messages." From a quick review, the size of the messages tends to be between 8K and 10K. We're bumping the limit to 16K. 

Example message for posterity: 
```
2024/09/17 08:44:12 [error] 190#0: *10751273 client intended to send too large body: 9585 bytes, client: 52.222.122.97, server: , request: "POST /?drain-type=all HTTP/1.1", host: "usagov-tools-logshipper.app.cloud.gov"
```