### PR TITLE
Specify version 3.1.10 of fluent-bit package

### DIFF
--- a/apt.yml
+++ b/apt.yml
@@ -4,4 +4,4 @@ keys:
 repos:
 - deb https://packages.fluentbit.io/ubuntu/jammy jammy main
 packages:
-- fluent-bit
+- fluent-bit=3.1.10


### PR DESCRIPTION
Fluentbit 3.2 is out and seems to have a bug; it fails when trying to load the plugin we specify in plugins.conf. This inspired me to figure out how to specify the version of fluent-bit that we want and have tested.

I've posted a note about this problem to the Fluent slack. I haven't taken the time to put together a reproducible test case (that doesn't involve cloud foundry) so I haven't opened a GitHub issue. (yet?) 

