### PR TITLE
Update fluent-bit to 3.2.10

### DIFF
--- a/apt.yml
+++ b/apt.yml
@@ -4,4 +4,4 @@ keys:
 repos:
 - deb https://packages.fluentbit.io/ubuntu/jammy jammy main
 packages:
-- fluent-bit=3.2.4
+- fluent-bit=3.2.10


### PR DESCRIPTION
Updates to the latest 3.2 patch-level version of fluent-bit. 